### PR TITLE
webserver: prepare for filtering with GET-querys

### DIFF
--- a/modules/webserver.js
+++ b/modules/webserver.js
@@ -30,11 +30,12 @@ module.exports = function(index, configData) {
   http.createServer(function(req, stream) {
     stream.setHeader('Access-Control-Allow-Origin', '*')
 
+    var url = require("url").parse(req.url, true) // true to get query as object
     var success = false
 
     for (let path in index) {
-      if (req.url == '/' + path) {
-        index[path](stream)
+      if (url.pathname == '/' + path) {
+        index[path](stream /*, url.query */) // uncomment if provider can handle the query (e.g. {filter: 'site', value: 'ffgc'})
         success = true
       }
     }


### PR DESCRIPTION
e.g. `<address>/nodes.json?filter=site&value=<site-code>`

handling is not implemented yet!

see also #14 