### PR TITLE
Add nodes.json filters for domain and domain_fallback_site

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Note: The default paths for configuration and state files might have changed. Ma
 
 ### Filternames
 - site
+- domain
+- domain_fallback_site
 - firmware_release
 - firstseen
 - lastseen

--- a/modules/receiver.js
+++ b/modules/receiver.js
@@ -160,6 +160,14 @@ module.exports = function (observer, configData) {
       return _.pickBy(data, function(o) {
         return _.includes(_.split(query.value, ','), _.get(o, 'nodeinfo.system.site_code', 'unknown'))
       })
+    case 'domain':
+      return _.pickBy(data, function(o) {
+        return _.includes(_.split(query.value, ','), _.get(o, 'nodeinfo.system.domain_code', 'unknown'))
+      })
+    case 'domain_fallback_site':
+      return _.pickBy(data, function(o) {
+        return _.includes(_.split(query.value, ','), _.get(o, 'nodeinfo.system.domain_code', _.get(o, 'nodeinfo.system.site_code', 'unknown')))
+      })
     case 'firmware_release':
       return _.pickBy(data, function(o) {
         return _.includes(_.split(query.value, ','), _.get(o, 'nodeinfo.software.firmware.release', 'unknown'))


### PR DESCRIPTION
Since the Gluon firmware comes with multidomain support, we have to determine the nodes of a community via the nodeinfo field "domain_code".
As an backwards compatible solution we need a "domain_fallback_site" filter to get all nodes that have not multidomain firmware yet.

The "domain_fallback_site"-Filter firstly tries to use the "domain_code" field and will fallback to the "site_code" field when not exists.